### PR TITLE
Matchmaker landing rewrite

### DIFF
--- a/src/pages/docs/matchmaker/index.mdx
+++ b/src/pages/docs/matchmaker/index.mdx
@@ -9,12 +9,32 @@ import { HeroPattern } from '@/components/HeroPattern';
 
 The Rivet Matchmaker is a casual matchmaker optimized to get your player connected to your game server in under a second in the optimal region & lobby.
 
-To integrate the Rivet matchmaker, your game needs to call these four endpoints:
+## Integration
 
-- **[matchmaker.lobbies.find](/docs/matchmaker/api/lobbies/find)**: Called on the game client to return the address to connect to & the player token
-- **[matchmaker.lobbies.ready](/docs/matchmaker/api/lobbies/ready)**: Called on the game server to notify the matchmaker that the game server is ready to accept players
-- **[matchmaker.players.connected](/docs/matchmaker/api/players/connected)**: Called on the game server to notify the matchmaker the player connected & verify the player token
-- **[matchmaker.players.disconnected](/docs/matchmaker/api/players/disconnected)**: Called on the game server to notify the matchmaker the player disconnected
+To integrate your servers to the Rivet Matchmaker system, you need to call these three endpoints in your server code.
+
+- **[matchmaker.lobbies.ready](/docs/matchmaker/api/lobbies/ready)**: Notifies the matchmaker that the server is ready to accept players
+- **[matchmaker.players.connected](/docs/matchmaker/api/players/connected)**: Notifies the matchmaker of a player connection while confirming the connection’s legitimacy
+- **[matchmaker.players.disconnected](/docs/matchmaker/api/players/disconnected)**: Notifies the matchmaker of a player disconnection
+
+And don't worry about notifying the matchmaker if your lobby closes or crashes, that gets taken internally by the Dynamic Server system. Although if you want to manually tell the matchmaker to stop letting in new players, you can call the **[matchmaker.lobbies.setClosed](/docs/matchmaker/api/lobbies/set-closed)** endpoint.
+
+## Connecting to lobbies
+
+Once integrated, you can call the following endpoints to find and join available lobbies in your client code.
+
+- **[matchmaker.lobbies.find](/docs/matchmaker/api/lobbies/find)**: Finds an available lobby and grants a player token to connect
+- **[matchmaker.lobbies.join](/docs/matchmaker/api/lobbies/join)**: Given a lobby’s id, grants a player token to be used for connection
+
+If you want the client to be able to create a whole new lobby (for things like private games), you can also use the **[matchmaker.lobbies.create](/docs/matchmaker/api/lobbies/create)** endpoint.
+
+## Getting other lobby info
+
+Additionally, you can make use of these endpoints to get more information about your game’s lobbies.
+
+- **[matchmaker.regions.list](/docs/matchmaker/api/regions/list)**: Returns listing of all regions available in game
+- **[matchmaker.lobbies.list](/docs/matchmaker/api/lobbies/list)**: Returns listing of all the lobbies linked to the matchmaker
+- **[matchmaker.players.getStatistics](/docs/matchmaker/api/players/get-statistics)**: Returns player count statistics by region and game mode
 
 The Rivet Matchmaker is tightly integrated with Dynamic Servers to automatically boot lobbies on-demand when players need them. Read more about how Rivet Dynamic Servers operates your game servers [here](/docs/dynamic-servers/index).
 


### PR DESCRIPTION
Issues from previous version:
1. Not visually obvious on which endpoints were to be run on clientside vs serverside
2. /join was not mentioned at all
3. Descriptions were matchmaker centered, vs instead, developer or game centered

Solutions proposed:
1. Reorganize prominent endpoints into server / client / other
2. Adjust descriptions of some endpoints on index