### PR TITLE
Add basic cloud api description

### DIFF
--- a/src/pages/docs/cloud/index.mdx
+++ b/src/pages/docs/cloud/index.mdx
@@ -5,3 +5,5 @@ import { HeroPattern } from '@/components/HeroPattern';
 # Cloud
 
 <Summary>APIs used to manage your game</Summary>
+
+For developers looking to add more layers of automation to their games on Rivet, the Rivet Cloud API provides a verbose collection of endpoints that interact with all your game’s infrastructure directly. Practically all of these will require a valid Cloud Token; See Rivet's token types page [here](/docs/general/concepts/token-types#cloud) for more info about cloud tokens.


### PR DESCRIPTION
Not sure if this exists already, in the future, should add some pages describing what _versions_, _namespaces_, etc are; that way we can add some more info outlining how they can be managed in the Cloud API index page.

Until, this PR adds some preliminary info on what's considered part of the cloud api and what's required to interact with the API