### PR TITLE
Remove excess separators

### DIFF
--- a/src/pages/learn/godot/tutorials/bomber-demo/index.mdx
+++ b/src/pages/learn/godot/tutorials/bomber-demo/index.mdx
@@ -12,8 +12,6 @@ Godot 4.2.
 
 <Warning>If you are using Godot 4.1/4.0/3.x, please be aware that some details may be different.</Warning>
 
----
-
 ## Overview
 
 Godot provides great multiplayer capabilities out of the box. In this tutorial,
@@ -23,8 +21,6 @@ but it's easy to swap out for another of Godot's high-level networking APIs.
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <Image src={preview} alt='Godot bomber demo preview' />
 </div>
-
----
 
 ## Step 1: Clone project
 

--- a/src/pages/learn/godot/tutorials/crash-course/index.mdx
+++ b/src/pages/learn/godot/tutorials/crash-course/index.mdx
@@ -10,8 +10,6 @@ Godot 4.
 
 <Warning>If you are using Godot 3, please be aware that some details may be different.</Warning>
 
----
-
 ## Overview
 
 Godot provides great multiplayer capabilities out of the box. We'll be using
@@ -20,8 +18,6 @@ top of Rivet.
 
 Godot supports ENet, WebSocket, and WebRTC transports. We'll be using ENet for
 this tutorial, but it's easy to swap out.
-
----
 
 ## Step 1: Initialize project
 

--- a/src/pages/learn/html5/tutorials/crash-course.mdx
+++ b/src/pages/learn/html5/tutorials/crash-course.mdx
@@ -32,8 +32,6 @@ You'll need a `Dockerfile` to build and run your game server.
 
 <UnfamiliarWithDockerfiles />
 
----
-
 ## Step 2: Integrate Rivet Matchmaker
 
 ### Install the Rivet library
@@ -92,8 +90,6 @@ myGameServer.on("connect", await (socket) => {
 ```
 
 <EnvTokenServer />
-
----
 
 ## Step 3: Publish your game
 

--- a/src/pages/learn/html5/tutorials/tanks-canvas-socketio.mdx
+++ b/src/pages/learn/html5/tutorials/tanks-canvas-socketio.mdx
@@ -84,8 +84,6 @@ Run the following command to setup your project:
 
 <WhatDoesRivetDo />
 
----
-
 ## Step 2: Integrate Rivet Matchmaker
 
 ### Install `@rivet-gg/api`
@@ -156,8 +154,6 @@ async function setupConnection(socket: Socket) {
   new Connection(game, socket);
 }
 ```
-
----
 
 ## Step 3: Deploy to Rivet
 


### PR DESCRIPTION
Headers already have separators. This is old from the Mintlify days.
