### PR TITLE
fix: provide second part of title for general docs

### DIFF
--- a/src/app/(v2)/docs/[...slug]/page.tsx
+++ b/src/app/(v2)/docs/[...slug]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({ params: { slug } }): Promise<Metadata> 
   const isEngine = ENGINES.includes(slug[0]);
   const isCore = CORE_DIRECTORIES.includes(slug[1]);
   return {
-    title: `${title} - ${ENGINE_LABEL_MAP[slug[0]]} - Rivet Docs`,
+    title: `${title} - ${ENGINE_LABEL_MAP[slug[0]] || ENGINE_LABEL_MAP.default} - Rivet Docs`,
     description,
     alternates:
       isEngine && isCore

--- a/src/lib/sameAs.ts
+++ b/src/lib/sameAs.ts
@@ -8,6 +8,7 @@ export const ENGINE_LABEL_MAP = {
   unreal: "Unreal",
   html5: "HTML5",
   custom: "Custom",
+  default: "General",
 };
 
 export function getAliasedSlug(slug: string[]) {


### PR DESCRIPTION
Closes [WEB-163](https://linear.app/rivet-gg/issue/WEB-163/fix-page-title-displaying-undefined-in-rivet-docs)